### PR TITLE
FMWK-577 Use count() instead of size() in DSP path

### DIFF
--- a/src/main/antlr4/com/aerospike/dsl/Condition.g4
+++ b/src/main/antlr4/com/aerospike/dsl/Condition.g4
@@ -460,7 +460,6 @@ pathFunction
     | 'increment' '()'
     | 'clear' '()'
     | 'sort' '()'
-    | pathFunctionSize
     ;
 
 pathFunctionCast: PATH_FUNCTION_CAST;
@@ -477,10 +476,6 @@ PATH_FUNCTION_EXISTS: 'exists' '()';
 pathFunctionCount: PATH_FUNCTION_COUNT;
 
 PATH_FUNCTION_COUNT: 'count' '()';
-
-pathFunctionSize: PATH_FUNCTION_SIZE;
-
-PATH_FUNCTION_SIZE: 'size' '()';
 
 pathFunctionGet
     : PATH_FUNCTION_GET '(' pathFunctionParams ')'

--- a/src/main/java/com/aerospike/dsl/ExpressionConditionVisitor.java
+++ b/src/main/java/com/aerospike/dsl/ExpressionConditionVisitor.java
@@ -401,11 +401,6 @@ public class ExpressionConditionVisitor extends ConditionBaseVisitor<AbstractPar
     }
 
     @Override
-    public AbstractPart visitPathFunctionSize(ConditionParser.PathFunctionSizeContext ctx) {
-        return new PathFunction(PathFunction.PathFunctionType.SIZE, null, null);
-    }
-
-    @Override
     public AbstractPart visitPathFunctionGet(ConditionParser.PathFunctionGetContext ctx) {
         PathFunction.ReturnParam returnParam = null;
         Exp.Type binType = null;
@@ -713,8 +708,8 @@ public class ExpressionConditionVisitor extends ConditionBaseVisitor<AbstractPar
         List<AbstractPart> parts = basePath.getParts();
 
         // if there are other parts except bin, get a corresponding Exp
-        if (!parts.isEmpty() || ctx.pathFunction() != null && ctx.pathFunction().pathFunctionSize() != null) {
-            Exp exp = PathOperand.processPath(basePath, ctx.pathFunction() == null
+        if (!parts.isEmpty() || ctx.pathFunction() != null && ctx.pathFunction().pathFunctionCount() != null) {
+                Exp exp = PathOperand.processPath(basePath, ctx.pathFunction() == null
                     ? null
                     : (PathFunction) visit(ctx.pathFunction()));
             return new PathOperand(exp);

--- a/src/test/java/com/aerospike/dsl/MapAndListExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/MapAndListExpressionsTests.java
@@ -110,8 +110,8 @@ public class MapAndListExpressionsTests {
                         )
                 ),
                 Exp.val(100));
-        translateAndCompare("$.listBin1.[1].a.[0].size() == 100", expected);
-        translateAndCompare("$.listBin1.[1].a.[0].[].size() == 100", expected);
+        translateAndCompare("$.listBin1.[1].a.[0].count() == 100", expected);
+        translateAndCompare("$.listBin1.[1].a.[0].[].count() == 100", expected);
     }
 
     @Test

--- a/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
@@ -113,15 +113,15 @@ public class MapExpressionsTests {
                         Exp.mapBin("mapBin1")
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.{}.size() > 200", expected);
+        translateAndCompare("$.mapBin1.{}.count() > 200", expected);
 
-        // the default behaviour for size() without List '[]' or Map '{}' designators is List
+        // the default behaviour for count() without List '[]' or Map '{}' designators is List
         Exp expected2 = Exp.gt(
                 ListExp.size(
                         Exp.listBin("mapBin1")
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.size() > 200", expected2);
+        translateAndCompare("$.mapBin1.count() > 200", expected2);
     }
 
     @Test
@@ -135,9 +135,9 @@ public class MapExpressionsTests {
                                 Exp.mapBin("mapBin1"))
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.a.{}.size() == 200", expected);
+        translateAndCompare("$.mapBin1.a.{}.count() == 200", expected);
 
-        // the default behaviour for size() without List '[]' or Map '{}' designators is List
+        // the default behaviour for count() without List '[]' or Map '{}' designators is List
         Exp expected2 = Exp.eq(
                 ListExp.size(
                         MapExp.getByKey(MapReturnType.VALUE,
@@ -146,7 +146,7 @@ public class MapExpressionsTests {
                                 Exp.mapBin("mapBin1"))
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.a.size() == 200", expected2);
+        translateAndCompare("$.mapBin1.a.count() == 200", expected2);
     }
 
     @Test
@@ -161,9 +161,9 @@ public class MapExpressionsTests {
                                 CTX.mapKey(Value.get("a")))
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.a.b.{}.size() == 200", expected);
+        translateAndCompare("$.mapBin1.a.b.{}.count() == 200", expected);
 
-        // the default behaviour for size() without List '[]' or Map '{}' designators is List
+        // the default behaviour for count() without List '[]' or Map '{}' designators is List
         Exp expected2 = Exp.eq(
                 ListExp.size(
                         MapExp.getByKey(MapReturnType.VALUE,
@@ -173,7 +173,7 @@ public class MapExpressionsTests {
                                 CTX.mapKey(Value.get("a")))
                 ),
                 Exp.val(200));
-        translateAndCompare("$.mapBin1.a.b.size() == 200", expected2);
+        translateAndCompare("$.mapBin1.a.b.count() == 200", expected2);
     }
 
     @Test
@@ -210,13 +210,20 @@ public class MapExpressionsTests {
     @Test
     void mapByValueCount() {
         Exp expected = Exp.gt(
-                MapExp.getByValue(
-                        MapReturnType.COUNT,
-                        Exp.val(100),
-                        Exp.mapBin("mapBin1")
-                ),
-                Exp.val(0));
+                MapExp.size(Exp.mapBin("mapBin1"), CTX.mapValue(Value.get(100))),
+                Exp.val(0)
+        );
         translateAndCompare("$.mapBin1.{=100}.count() > 0", expected);
+
+        Exp expected2 = Exp.gt(
+                MapExp.size(
+                        MapExp.getByValue(MapReturnType.VALUE,
+                                Exp.val(100),
+                                Exp.mapBin("mapBin1"))
+                ),
+                Exp.val(0)
+        );
+        translateAndCompare("$.mapBin1.{=100}.{}.count() > 0", expected2); // TODO: unify
     }
 
     @Test


### PR DESCRIPTION
- only count() will be supported in DSL path to remove ambiguity
- actual size() operations are applied for CDT non-range count, otherwise get operations with ReturnType count