### PR TITLE
FMWK-578 Fix valueType in CDT count

### DIFF
--- a/src/test/java/com/aerospike/dsl/ListExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/ListExpressionsTests.java
@@ -145,7 +145,7 @@ class ListExpressionsTests {
         Exp expected = Exp.eq(
                 ListExp.size(
                         ListExp.getByIndex(ListReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.LIST,
                                 Exp.val(1),
                                 Exp.listBin("listBin1"))
                 ),
@@ -163,7 +163,7 @@ class ListExpressionsTests {
         Exp expected = Exp.eq(
                 ListExp.size(
                         ListExp.getByIndex(ListReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.LIST,
                                 Exp.val(2),
                                 Exp.listBin("listBin1"),
                                 CTX.listIndex(1))
@@ -224,7 +224,7 @@ class ListExpressionsTests {
         Exp expected = Exp.eq(
                 ListExp.size(
                         ListExp.getByIndex(ListReturnType.VALUE,
-                                Exp.Type.INT, // TODO: must be LIST
+                                Exp.Type.LIST,
                                 Exp.val(0),
                                 Exp.listBin("listBin1"))
                 ),

--- a/src/test/java/com/aerospike/dsl/MapAndListExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/MapAndListExpressionsTests.java
@@ -102,7 +102,7 @@ public class MapAndListExpressionsTests {
                 ListExp.size(
                         ListExp.getByIndex(
                                 ListReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.LIST,
                                 Exp.val(0),
                                 Exp.listBin("listBin1"),
                                 CTX.listIndex(1),

--- a/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
@@ -130,18 +130,18 @@ public class MapExpressionsTests {
         Exp expected = Exp.eq(
                 MapExp.size(
                         MapExp.getByKey(ListReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.MAP,
                                 Exp.val("a"),
                                 Exp.mapBin("mapBin1"))
                 ),
                 Exp.val(200));
         translateAndCompare("$.mapBin1.a.{}.count() == 200", expected);
 
-        // the default behaviour for count() without List '[]' or Map '{}' designators is List
+        // the default behaviour for count() without Map '{}' or List '[]' designators is List
         Exp expected2 = Exp.eq(
                 ListExp.size(
                         MapExp.getByKey(MapReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.LIST,
                                 Exp.val("a"),
                                 Exp.mapBin("mapBin1"))
                 ),
@@ -155,7 +155,7 @@ public class MapExpressionsTests {
         Exp expected = Exp.eq(
                 MapExp.size(
                         MapExp.getByKey(ListReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.MAP,
                                 Exp.val("b"),
                                 Exp.mapBin("mapBin1"),
                                 CTX.mapKey(Value.get("a")))
@@ -163,11 +163,11 @@ public class MapExpressionsTests {
                 Exp.val(200));
         translateAndCompare("$.mapBin1.a.b.{}.count() == 200", expected);
 
-        // the default behaviour for count() without List '[]' or Map '{}' designators is List
+        // the default behaviour for count() without Map '{}' or List '[]' designators is List
         Exp expected2 = Exp.eq(
                 ListExp.size(
                         MapExp.getByKey(MapReturnType.VALUE,
-                                Exp.Type.INT,
+                                Exp.Type.LIST,
                                 Exp.val("b"),
                                 Exp.mapBin("mapBin1"),
                                 CTX.mapKey(Value.get("a")))


### PR DESCRIPTION
Fix valueType in count() CDT operation, e.g., for path like `$.listBin1.[1].[].count() == 100` it must be Exp.Type.LIST