### PR TITLE
FMWK-580 Count by CDT value

### DIFF
--- a/src/main/java/com/aerospike/dsl/model/cdt/list/ListValue.java
+++ b/src/main/java/com/aerospike/dsl/model/cdt/list/ListValue.java
@@ -20,7 +20,12 @@ public class ListValue extends ListPart {
 
     @Override
     public Exp constructExp(BasePath basePath, Exp.Type valueType, int cdtReturnType, CTX[] context) {
-        Exp value = getExpVal(valueType, getValue());
+        Exp value = switch (valueType) {
+            case BOOL -> Exp.val((Boolean) getValue());
+            case STRING -> Exp.val((String) getValue());
+            case FLOAT -> Exp.val((Float) getValue());
+            default -> Exp.val((Integer) getValue()); // for getByValue the default is INT
+        };
         return ListExp.getByValue(cdtReturnType, value, Exp.bin(basePath.getBinPart().getBinName(),
                 basePath.getBinType()), context);
     }

--- a/src/main/java/com/aerospike/dsl/model/cdt/map/MapValue.java
+++ b/src/main/java/com/aerospike/dsl/model/cdt/map/MapValue.java
@@ -20,7 +20,12 @@ public class MapValue extends MapPart {
 
     @Override
     public Exp constructExp(BasePath basePath, Exp.Type valueType, int cdtReturnType, CTX[] context) {
-        Exp value = getExpVal(valueType, getValue());
+        Exp value = switch (valueType) {
+            case BOOL -> Exp.val((Boolean) getValue());
+            case STRING -> Exp.val((String) getValue());
+            case FLOAT -> Exp.val((Float) getValue());
+            default -> Exp.val((Integer) getValue()); // for getByValue the default is INT
+        };
         return MapExp.getByValue(cdtReturnType, value, Exp.bin(basePath.getBinPart().getBinName(),
                 basePath.getBinType()), context);
     }

--- a/src/test/java/com/aerospike/dsl/ListExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/ListExpressionsTests.java
@@ -1,6 +1,5 @@
 package com.aerospike.dsl;
 
-import com.aerospike.client.Value;
 import com.aerospike.client.cdt.CTX;
 import com.aerospike.client.cdt.ListReturnType;
 import com.aerospike.client.exp.Exp;
@@ -79,20 +78,13 @@ class ListExpressionsTests {
     @Test
     void listByValueCount() {
         Exp expected = Exp.gt(
-                ListExp.size(Exp.listBin("listBin1"), CTX.listValue(Value.get(100))),
+                ListExp.getByValue(ListReturnType.COUNT,
+                        Exp.val(100),
+                        Exp.listBin("listBin1")),
                 Exp.val(0)
         );
         translateAndCompare("$.listBin1.[=100].count() > 0", expected);
-
-        Exp expected2 = Exp.gt(
-                ListExp.size(
-                        ListExp.getByValue(ListReturnType.VALUE,
-                                Exp.val(100),
-                                Exp.listBin("listBin1"))
-                ),
-                Exp.val(0)
-        );
-        translateAndCompare("$.listBin1.[=100].[].count() > 0", expected2); // TODO: unify
+        translateAndCompare("$.listBin1.[=100].[].count() > 0", expected);
     }
 
     @Test

--- a/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/MapExpressionsTests.java
@@ -210,20 +210,13 @@ public class MapExpressionsTests {
     @Test
     void mapByValueCount() {
         Exp expected = Exp.gt(
-                MapExp.size(Exp.mapBin("mapBin1"), CTX.mapValue(Value.get(100))),
+                MapExp.getByValue(MapReturnType.COUNT,
+                        Exp.val(100),
+                        Exp.mapBin("mapBin1")),
                 Exp.val(0)
         );
         translateAndCompare("$.mapBin1.{=100}.count() > 0", expected);
-
-        Exp expected2 = Exp.gt(
-                MapExp.size(
-                        MapExp.getByValue(MapReturnType.VALUE,
-                                Exp.val(100),
-                                Exp.mapBin("mapBin1"))
-                ),
-                Exp.val(0)
-        );
-        translateAndCompare("$.mapBin1.{=100}.{}.count() > 0", expected2); // TODO: unify
+        translateAndCompare("$.mapBin1.{=100}.{}.count() > 0", expected);
     }
 
     @Test


### PR DESCRIPTION
- Make count by CDT value return the same expression regardless of explicit CDT designator
- getByValue is potentially returning multiple elements, so it must be a GET operation in case of .count()