### PR TITLE
CLIENT-4543 remove get with no params from grammar

### DIFF
--- a/src/main/antlr4/com/aerospike/dsl/Condition.g4
+++ b/src/main/antlr4/com/aerospike/dsl/Condition.g4
@@ -534,6 +534,7 @@ PATH_FUNCTION_COUNT: 'count' '()';
 
 pathFunctionGet
     : PATH_FUNCTION_GET '(' pathFunctionParams ')'
+    | PATH_FUNCTION_GET '()'
     ;
 
 pathFunctionParams: pathFunctionParam (',' pathFunctionParam)*?;

--- a/src/main/antlr4/com/aerospike/dsl/Condition.g4
+++ b/src/main/antlr4/com/aerospike/dsl/Condition.g4
@@ -534,7 +534,6 @@ PATH_FUNCTION_COUNT: 'count' '()';
 
 pathFunctionGet
     : PATH_FUNCTION_GET '(' pathFunctionParams ')'
-    | PATH_FUNCTION_GET '()'
     ;
 
 pathFunctionParams: pathFunctionParam (',' pathFunctionParam)*?;

--- a/src/main/java/com/aerospike/dsl/visitor/ExpressionConditionVisitor.java
+++ b/src/main/java/com/aerospike/dsl/visitor/ExpressionConditionVisitor.java
@@ -776,12 +776,15 @@ public class ExpressionConditionVisitor extends ConditionBaseVisitor<AbstractPar
     public AbstractPart visitPathFunctionGet(ConditionParser.PathFunctionGetContext ctx) {
         PathFunction.ReturnParam returnParam = null;
         Exp.Type binType = null;
-        for (ConditionParser.PathFunctionParamContext paramCtx : ctx.pathFunctionParams().pathFunctionParam()) {
-            if (paramCtx != null) {
-                String typeVal = getPathFunctionParam(paramCtx, "type");
-                if (typeVal != null) binType = Exp.Type.valueOf(typeVal);
-                String returnVal = getPathFunctionParam(paramCtx, "return");
-                if (returnVal != null) returnParam = PathFunction.ReturnParam.valueOf(returnVal);
+        ConditionParser.PathFunctionParamsContext params = ctx.pathFunctionParams();
+        if (params != null) {
+            for (ConditionParser.PathFunctionParamContext paramCtx : params.pathFunctionParam()) {
+                if (paramCtx != null) {
+                    String typeVal = getPathFunctionParam(paramCtx, "type");
+                    if (typeVal != null) binType = Exp.Type.valueOf(typeVal);
+                    String returnVal = getPathFunctionParam(paramCtx, "return");
+                    if (returnVal != null) returnParam = PathFunction.ReturnParam.valueOf(returnVal);
+                }
             }
         }
         return new PathFunction(PathFunction.PathFunctionType.GET, returnParam, binType);

--- a/src/test/java/com/aerospike/dsl/expression/BinExpressionsTests.java
+++ b/src/test/java/com/aerospike/dsl/expression/BinExpressionsTests.java
@@ -60,6 +60,7 @@ class BinExpressionsTests {
         parseFilterExpressionAndCompare(ExpressionContext.of("$.intBin1 != 100"), Exp.ne(Exp.intBin("intBin1"), Exp.val(100)));
         parseFilterExpressionAndCompare(ExpressionContext.of("$.strBin != \"yes\""), Exp.ne(Exp.stringBin("strBin"), Exp.val("yes")));
         parseFilterExpressionAndCompare(ExpressionContext.of("$.strBin != 'yes'"), Exp.ne(Exp.stringBin("strBin"), Exp.val("yes")));
+        parseFilterExpressionAndCompare(ExpressionContext.of("$.intBin1.get() != 100"), Exp.ne(Exp.intBin("intBin1"), Exp.val(100)));
     }
 
     @Test


### PR DESCRIPTION
  ` | PATH_FUNCTION_GET '()'` allows to have expressions like: 

`"$.intBin1.get() != 100"`

But they are not parsed properly by the current visitor implementations.

So, either we should modify the grammar to not have `get()` or update the visitor classes to parse `intBin1.get()` as `intBin1`